### PR TITLE
fix: strip intermediate sourceMappingURL comments

### DIFF
--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -92,6 +92,9 @@ export const transform = (enableSourcemap: boolean) => {
       const isEntry = Boolean(moduleId && this.getModuleInfo(moduleId)?.isEntry);
       const isJSON = Boolean(moduleId && JSON_EXTENSIONS.test(moduleId));
 
+      // Preserve original code for loadInputSourcemap() before preProcess strips sourceMappingURL
+      const rawCode = code;
+
       let sourceFile = parse(fileName, code);
       const preprocessed = preProcess({ sourceFile, isEntry, isJSON });
       // `sourceFile.fileName` here uses forward slashes
@@ -123,7 +126,7 @@ export const transform = (enableSourcemap: boolean) => {
       if (DTS_EXTENSIONS.test(fileName)) {
         pendingSourcemaps.set(fileName, {
           fileName,
-          originalCode: code,
+          originalCode: rawCode,
           inputMapText,
         });
       }

--- a/src/transform/preprocess.ts
+++ b/src/transform/preprocess.ts
@@ -336,6 +336,31 @@ export function preProcess({ sourceFile, isEntry, isJSON }: PreProcessInput): Pr
     code.remove(start, end);
   }
 
+  // Strip trailing sourceMappingURL comments so they don't leak into bundled output
+  const fullText = sourceFile.getFullText();
+
+  // Check EOF token's leading trivia (comment on its own line after last statement)
+  // and last statement's trailing trivia (comment on same line as last statement)
+  const eofTrivia = ts.getLeadingCommentRanges(fullText, sourceFile.endOfFileToken.getFullStart());
+  const lastStatement = sourceFile.statements[sourceFile.statements.length - 1];
+  const trailingTrivia = lastStatement
+    ? ts.getTrailingCommentRanges(fullText, lastStatement.getEnd())
+    : undefined;
+
+  for (const comment of [...(eofTrivia ?? []), ...(trailingTrivia ?? [])]) {
+    // Skip block comments — sourceMappingURL text inside /** */ must not be stripped
+    if (comment.kind !== ts.SyntaxKind.SingleLineCommentTrivia) continue;
+    const text = fullText.slice(comment.pos, comment.end);
+    if (!/\/\/[#@]\s*sourceMappingURL=/.test(text)) continue;
+
+    let start = comment.pos;
+    if (start > 0 && fullText[start - 1] === "\n") {
+      start -= 1;
+    }
+    code.remove(start, comment.end);
+    break;
+  }
+
   return {
     code,
     typeReferences,

--- a/tests/testcases/sourcemapping-url-in-block-comment/expected.d.ts
+++ b/tests/testcases/sourcemapping-url-in-block-comment/expected.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  interface Window {
+    __TEST__: string;
+  }
+}
+/** Parser hint: //# sourceMappingURL=generated.map */
+declare const value: string;
+declare const result: typeof value;
+export { result };

--- a/tests/testcases/sourcemapping-url-in-block-comment/index.d.ts
+++ b/tests/testcases/sourcemapping-url-in-block-comment/index.d.ts
@@ -1,0 +1,3 @@
+import { value } from "./second";
+
+export declare const result: typeof value;

--- a/tests/testcases/sourcemapping-url-in-block-comment/second.d.ts
+++ b/tests/testcases/sourcemapping-url-in-block-comment/second.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    __TEST__: string;
+  }
+}
+/** Parser hint: //# sourceMappingURL=generated.map */
+export declare const value: string;

--- a/tests/testcases/sourcemapping-url-in-trailing-block-comment/expected.d.ts
+++ b/tests/testcases/sourcemapping-url-in-trailing-block-comment/expected.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    __TEST__: string;
+  }
+}
+declare const value: string;
+declare const result: typeof value;
+export { result };

--- a/tests/testcases/sourcemapping-url-in-trailing-block-comment/index.d.ts
+++ b/tests/testcases/sourcemapping-url-in-trailing-block-comment/index.d.ts
@@ -1,0 +1,3 @@
+import { value } from "./second";
+
+export declare const result: typeof value;

--- a/tests/testcases/sourcemapping-url-in-trailing-block-comment/second.d.ts
+++ b/tests/testcases/sourcemapping-url-in-trailing-block-comment/second.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    __TEST__: string;
+  }
+}
+
+export declare const value: string;
+/** //# sourceMappingURL=generated.map */

--- a/tests/testcases/strip-sourcemapping-url-at-sign/expected.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-at-sign/expected.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    __TEST__: string;
+  }
+}
+declare const value: string;
+declare const result: typeof value;
+export { result };

--- a/tests/testcases/strip-sourcemapping-url-at-sign/index.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-at-sign/index.d.ts
@@ -1,0 +1,3 @@
+import { value } from "./second";
+
+export declare const result: typeof value;

--- a/tests/testcases/strip-sourcemapping-url-at-sign/second.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-at-sign/second.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    __TEST__: string;
+  }
+}
+
+export declare const value: string;
+//@ sourceMappingURL=second.d.ts.map

--- a/tests/testcases/strip-sourcemapping-url-comment/expected.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-comment/expected.d.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Window {
+    __ENVIRONMENT__: Environment;
+  }
+}
+declare enum Environment {
+  Development = "development",
+  Production = "production"
+}
+declare const env: Environment;
+export { Environment, env };

--- a/tests/testcases/strip-sourcemapping-url-comment/index.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-comment/index.d.ts
@@ -1,0 +1,4 @@
+import { Environment } from "./second";
+
+export declare const env: Environment;
+export type { Environment };

--- a/tests/testcases/strip-sourcemapping-url-comment/second.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-comment/second.d.ts
@@ -1,0 +1,13 @@
+declare global {
+  interface Window {
+    __ENVIRONMENT__: Environment;
+  }
+}
+declare enum Environment {
+  Development = "development",
+  Production = "production"
+}
+declare function getEnvironment(): Environment;
+
+export { Environment, getEnvironment };
+//# sourceMappingURL=second.d.ts.map

--- a/tests/testcases/strip-sourcemapping-url-declare-module/expected.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-declare-module/expected.d.ts
@@ -1,0 +1,8 @@
+declare module "virtual:config" {
+  export const config: {
+    mode: string;
+  };
+}
+declare const mode: string;
+declare const currentMode: typeof mode;
+export { currentMode };

--- a/tests/testcases/strip-sourcemapping-url-declare-module/index.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-declare-module/index.d.ts
@@ -1,0 +1,3 @@
+import { mode } from "./second";
+
+export declare const currentMode: typeof mode;

--- a/tests/testcases/strip-sourcemapping-url-declare-module/second.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-declare-module/second.d.ts
@@ -1,0 +1,8 @@
+declare module "virtual:config" {
+  export const config: {
+    mode: string;
+  };
+}
+
+export declare const mode: string;
+//# sourceMappingURL=second.d.ts.map

--- a/tests/testcases/strip-sourcemapping-url-inline-base64/expected.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-inline-base64/expected.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    __APP_VERSION__: string;
+  }
+}
+declare const VERSION: string;
+declare const appVersion: typeof VERSION;
+export { appVersion };

--- a/tests/testcases/strip-sourcemapping-url-inline-base64/index.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-inline-base64/index.d.ts
@@ -1,0 +1,3 @@
+import { VERSION } from "./second";
+
+export declare const appVersion: typeof VERSION;

--- a/tests/testcases/strip-sourcemapping-url-inline-base64/second.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-inline-base64/second.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    __APP_VERSION__: string;
+  }
+}
+
+export declare const VERSION: string;
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic2Vjb25kLmQudHMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyIuLi9zcmMvc2Vjb25kLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBIn0=

--- a/tests/testcases/strip-sourcemapping-url-multiple-globals/expected.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-multiple-globals/expected.d.ts
@@ -1,0 +1,17 @@
+declare global {
+  interface Window {
+    __FEATURE_A__: boolean;
+  }
+}
+declare const featureA: boolean;
+declare global {
+  interface Window {
+    __FEATURE_B__: boolean;
+  }
+}
+declare const featureB: boolean;
+declare const flags: {
+  a: typeof featureA;
+  b: typeof featureB;
+};
+export { flags };

--- a/tests/testcases/strip-sourcemapping-url-multiple-globals/index.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-multiple-globals/index.d.ts
@@ -1,0 +1,7 @@
+import { featureA } from "./second";
+import { featureB } from "./third";
+
+export declare const flags: {
+  a: typeof featureA;
+  b: typeof featureB;
+};

--- a/tests/testcases/strip-sourcemapping-url-multiple-globals/second.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-multiple-globals/second.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    __FEATURE_A__: boolean;
+  }
+}
+
+export declare const featureA: boolean;
+//# sourceMappingURL=second.d.ts.map

--- a/tests/testcases/strip-sourcemapping-url-multiple-globals/third.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-multiple-globals/third.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    __FEATURE_B__: boolean;
+  }
+}
+
+export declare const featureB: boolean;
+//# sourceMappingURL=third.d.ts.map

--- a/tests/testcases/strip-sourcemapping-url-no-newline/expected.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-no-newline/expected.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  interface Window {
+    __CONFIG__: Config;
+  }
+}
+declare interface Config {
+  debug: boolean;
+}
+declare const config: Config;
+export { config };

--- a/tests/testcases/strip-sourcemapping-url-no-newline/index.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-no-newline/index.d.ts
@@ -1,0 +1,3 @@
+import { Config } from "./second";
+
+export declare const config: Config;

--- a/tests/testcases/strip-sourcemapping-url-no-newline/second.d.ts
+++ b/tests/testcases/strip-sourcemapping-url-no-newline/second.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  interface Window {
+    __CONFIG__: Config;
+  }
+}
+declare interface Config {
+  debug: boolean;
+}
+export { Config };//# sourceMappingURL=second.d.ts.map


### PR DESCRIPTION
## Problem

When a `.d.ts` module contains a side-effectful construct (`declare global` or `declare module "name"`) and a trailing `//# sourceMappingURL` comment, the comment leaks into the bundled output.

**Root cause:** Rollup renders modules using [MagicString](https://github.com/rollup/rollup/blob/7af842b3af052d1c305e90ac1fbf0cfb8c9fa359/src/Module.ts#L782-L791) (original source text), not AST reconstruction. Tree-shaken nodes are explicitly [removed](https://github.com/rollup/rollup/blob/7af842b3af052d1c305e90ac1fbf0cfb8c9fa359/src/utils/treeshakeNode.ts#L4-L7) via `code.remove()`, but included nodes are left as-is. In [`renderStatementList()`](https://github.com/rollup/rollup/blob/7af842b3af052d1c305e90ac1fbf0cfb8c9fa359/src/utils/renderHelpers.ts#L109-L153), text between the last included statement's `end` and the program's `end` is never removed — this is where `//# sourceMappingURL` comments live. Modules with `declare global` or `declare module` are side-effectful (the `Transformer` wraps them as IIFEs), so all their statements are included and trailing comments survive into the output.

**Result:** The bundled output contains multiple `sourceMappingURL` directives — one leaked from each bundled side-effectful dependency, plus the real one from Rollup's output. This breaks sourcemap tooling that expects exactly one directive per file.

**Reproduction:**

Input module (bundled devDependency):
```typescript
declare global {
  interface Window {
    __ENVIRONMENT__: Environment;
  }
}
declare enum Environment {
  Development = "development",
  Production = "production"
}
export { Environment };
//# sourceMappingURL=index.d.ts.map
```

Bundled output (broken):
```typescript
declare global { ... }
declare enum Environment { ... }
//# sourceMappingURL=index.d.ts.map   ← leaked from devDependency
declare const env: Environment;
export { Environment, env };
//# sourceMappingURL=index.d.ts.map   ← Rollup's own output sourcemap
```

## Solution

Strip `//# sourceMappingURL` comments during `preProcess` (per-module, before Rollup bundling) using TypeScript's comment range API.

### Why preProcess, not renderChunk?

`renderChunk` operates on the combined bundled output. A regex there could false-positive on `sourceMappingURL` text inside string literals, template literals, or block comments from any module. `preProcess` has per-module TypeScript parser context — safe to distinguish real directives from text that merely contains the string.

### Why the comment range API, not string search?

String-based approaches (`lastIndexOf`, regex on full text) match `//# sourceMappingURL=` text inside block comments:

```typescript
/** Parser hint: //# sourceMappingURL=generated.map */
export declare const value: string;
```

Stripping from the `//` position removes the closing `*/`, leaving an unclosed block comment that swallows the export → `"value" is not exported` error.

[`ts.getLeadingCommentRanges`](https://github.com/microsoft/TypeScript/blob/cdc205d5e6338d96b0fb54657af33d473d480a9c/src/compiler/scanner.ts#L957) / `ts.getTrailingCommentRanges` classify each comment by `kind` — `SingleLineCommentTrivia` (kind 2) vs `MultiLineCommentTrivia` (kind 3). We only strip kind 2, so `/** */` blocks are never touched.

### Two trivia locations

The sourceMappingURL can be in two positions:
- **EOF token leading trivia** — comment on its own line after the last statement (standard case, e.g. `tsc` output)
- **Last statement trailing trivia** — comment on the same line as the last statement, no preceding newline (e.g. minified output)

TypeScript's scanner only classifies a comment as "leading" trivia if it follows a line break ([`collecting = true` after newline — `scanner.ts:856`](https://github.com/microsoft/TypeScript/blob/cdc205d5e6338d96b0fb54657af33d473d480a9c/src/compiler/scanner.ts#L856)). Same-line comments are "trailing" trivia of the preceding token. The fix checks both locations.

### Preserving sourcemap loading

`preProcess` now strips the `//# sourceMappingURL` comment from the MagicString. But `loadInputSourcemap()` (in `sourcemap.ts`) uses `convert-source-map` to parse that comment from `originalCode` to locate inline or file-reference sourcemaps. Fix: save the raw input code before preprocessing and pass it as `originalCode` to `pendingSourcemaps`.

## Changes

- `src/transform/preprocess.ts` — Strip sourceMappingURL from EOF leading trivia and last-statement trailing trivia
- `src/transform/index.ts` — Preserve raw input code for sourcemap loading before preProcess modifies it

## Tests

### Stripping (directive should be removed)

| Test | Edge case |
|------|-----------|
| `strip-sourcemapping-url-comment` | Basic `declare global` + file-ref comment |
| `strip-sourcemapping-url-at-sign` | Legacy `//@ sourceMappingURL=...` format |
| `strip-sourcemapping-url-inline-base64` | Long `data:application/json;base64,...` URL |
| `strip-sourcemapping-url-multiple-globals` | Two side-effectful modules, each with comment |
| `strip-sourcemapping-url-no-newline` | `};//# sourceMappingURL=...` (no preceding newline) |
| `strip-sourcemapping-url-declare-module` | `declare module "name"` (ambient module, not just `declare global`) |

### Preservation (must NOT strip)

| Test | Edge case |
|------|-----------|
| `sourcemapping-url-in-block-comment` | `/** //# sourceMappingURL=... */` as JSDoc on a statement |
| `sourcemapping-url-in-trailing-block-comment` | `/** //# sourceMappingURL=... */` as trailing content after last statement |

### Existing sourcemap tests (regression)

`sourcemap/inline-base64`, `sourcemap/inline-urlencoded`, `sourcemap/file-reference` — all pass because `rawCode` (saved before preprocessing) is used for `loadInputSourcemap()`.
