### PR TITLE
fix: prevent `declare global` from being treated as an exported binding

### DIFF
--- a/src/transform/preprocess.ts
+++ b/src/transform/preprocess.ts
@@ -119,7 +119,10 @@ export function preProcess({ sourceFile, isEntry, isJSON }: PreProcessInput): Pr
         declaredNames.add(name);
 
         // collect the exported name, maybe as `default`.
-        if (matchesModifier(node, ts.ModifierFlags.ExportDefault)) {
+        // `declare global` blocks are global augmentations, not actual exports.
+        if (node.flags & ts.NodeFlags.GlobalAugmentation) {
+          // skip - global augmentations should never be exported
+        } else if (matchesModifier(node, ts.ModifierFlags.ExportDefault)) {
           defaultExport = name;
         } else if (
           (treatAsGlobalModule && ts.isIdentifier(node.name))

--- a/tests/testcases/declare-global-export-function/client.d.ts
+++ b/tests/testcases/declare-global-export-function/client.d.ts
@@ -1,0 +1,10 @@
+import type { Config } from './types';
+
+declare global {
+    interface Window {
+        __APP_CONFIG__?: Config;
+    }
+}
+
+export declare function getConfig(): Config | undefined;
+export declare function resetConfig(): void;

--- a/tests/testcases/declare-global-export-function/expected.d.ts
+++ b/tests/testcases/declare-global-export-function/expected.d.ts
@@ -1,0 +1,12 @@
+interface Config {
+    locale: string;
+    debug: boolean;
+}
+declare global {
+    interface Window {
+        __APP_CONFIG__?: Config;
+    }
+}
+declare function getConfig(): Config | undefined;
+declare function resetConfig(): void;
+export { getConfig, resetConfig };

--- a/tests/testcases/declare-global-export-function/index.d.ts
+++ b/tests/testcases/declare-global-export-function/index.d.ts
@@ -1,0 +1,1 @@
+export { getConfig, resetConfig } from './client';

--- a/tests/testcases/declare-global-export-function/types.d.ts
+++ b/tests/testcases/declare-global-export-function/types.d.ts
@@ -1,0 +1,4 @@
+export interface Config {
+    locale: string;
+    debug: boolean;
+}


### PR DESCRIPTION
## Summary
- When a non-entry `.d.ts` file has `declare global` alongside `export declare function`, the `isGlobalModule()` heuristic classifies it as a global module, causing "global" to be added to `exportedNames`
- The Transformer creates an anonymous IIFE for global augmentations (not a named binding), so Rollup errors with: `Exported variable "global" is not defined`
- Added a `GlobalAugmentation` flag check before adding names to `exportedNames`

## Related issues
- Similar to [Swatinem/rollup-plugin-dts#160](https://github.com/Swatinem/rollup-plugin-dts/issues/160) — also involves `declare global` blocks being mishandled during preprocessing, though that issue was about dotted namespace syntax (`Named.Core`) causing a `ModuleBlock` error, whereas this bug is about "global" being incorrectly added to the export list

## Test plan
- [x] New test case `declare-global-export-function` covers the exact pattern
- [x] All 142 existing tests pass